### PR TITLE
Fixing Bzip2 version detect by using --help instead of --version

### DIFF
--- a/spackdetect/packages/Bzip2.py
+++ b/spackdetect/packages/Bzip2.py
@@ -2,4 +2,4 @@ from ..PackageTypes import ExecutablePackage
 
 
 class Bzip2(ExecutablePackage):
-    pass
+    version_args = ['--help']


### PR DESCRIPTION
Changing the Bzip2 package class to use --help instead of the default version _args of --version
The --help option also displays the version number and doesn't hang like the --version option does. 

